### PR TITLE
New Resource for Audit Rules (Issue #11)

### DIFF
--- a/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
+++ b/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
@@ -421,7 +421,7 @@ function Set-TargetResource
             Write-Verbose -Message 'The default permission entry will be added.'
 
             $ReferenceRuleInfo += [PSCustomObject]@{
-                AccessControlType = 'Failure'
+                AuditFlags = 'Failure'
                 FileSystemRights = 'ReadAndExecute'
                 Inheritance = $null
                 NoPropagateInherit = $false

--- a/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
+++ b/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
@@ -1,0 +1,877 @@
+#requires -Version 4.0 -Modules CimCmdlets
+
+Set-StrictMode -Version Latest
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Principal
+    )
+
+    $Acl = Get-Acl -Path $Path -Audit -ErrorAction Stop
+
+    if ($Acl -is [System.Security.AccessControl.DirectorySecurity])
+    {
+        $ItemType = 'Directory'
+    }
+    else
+    {
+        $ItemType = 'File'
+    }
+
+    $Identity = Resolve-IdentityReference -Identity $Principal -ErrorAction Stop
+
+    [System.Security.AccessControl.FileSystemAuditRule[]]$AuditRules = @(
+        $Acl.Audit |
+        Where-Object -FilterScript {
+            ($_.IsInherited -eq $false) -and
+            ($_.IdentityReference -eq $Identity.Name)
+        }
+    )
+
+    Write-Verbose -Message "Current permission entry count : $($AuditRules.Count)"
+
+    $CimAccessRules = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+    if ($AuditRules.Count -eq 0)
+    {
+        $EnsureResult = 'Absent'
+    }
+    else
+    {
+        $EnsureResult = 'Present'
+
+        $AuditRules |
+        ConvertFrom-FileSystemAuditRule -ItemType $ItemType |
+        ForEach-Object -Process {
+
+            $CimAccessRule = New-CimInstance -ClientOnly `
+                -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                -ClassName cNtfsAuditRuleInformation `
+                -Property @{
+                    AuditFlags = $_.AuditFlags
+                    FileSystemRights = $_.FileSystemRights
+                    Inheritance = $_.Inheritance
+                    NoPropagateInherit = $_.NoPropagateInherit
+                }
+
+            $CimAccessRules.Add($CimAccessRule)
+
+        }
+    }
+
+    $ReturnValue = @{
+        Ensure = $EnsureResult
+        Path = $Path
+        ItemType = $ItemType
+        Principal = $Principal
+        AuditRuleInformation = [Microsoft.Management.Infrastructure.CimInstance[]]@($CimAccessRules)
+    }
+
+    return $ReturnValue
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Absent', 'Present')]
+        [String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Directory', 'File')]
+        [String]
+        $ItemType,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Principal,
+
+        [Parameter(Mandatory = $false)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AuditRuleInformation
+    )
+
+    $PSBoundParameters.GetEnumerator() |
+    ForEach-Object -Begin {
+        $Width = $PSBoundParameters.Keys.Length | Sort-Object | Select-Object -Last 1
+    } -Process {
+        "{0,-$($Width)} : '{1}'" -f $_.Key, ($_.Value -join ', ') |
+        Write-Verbose
+    }
+
+    if ($PSBoundParameters.ContainsKey('ItemType'))
+    {
+        Write-Verbose -Message 'The ItemType property is deprecated and will be ignored.'
+    }
+
+    $InDesiredState = $true
+
+    $Acl = Get-Acl -Path $Path -Audit -ErrorAction Stop
+
+    if ($Acl -is [System.Security.AccessControl.DirectorySecurity])
+    {
+        $ItemType = 'Directory'
+    }
+    else
+    {
+        $ItemType = 'File'
+    }
+
+    $Identity = Resolve-IdentityReference -Identity $Principal -ErrorAction Stop
+
+    [System.Security.AccessControl.FileSystemAuditRule[]]$AuditRules = @(
+        $Acl.Audit |
+        Where-Object -FilterScript {
+            ($_.IsInherited -eq $false) -and
+            ($_.IdentityReference -eq $Identity.Name)
+        }
+    )
+
+    Write-Verbose -Message "Current permission entry count : $($AuditRules.Count)"
+
+    [PSCustomObject[]]$ReferenceRuleInfo = @()
+
+    if ($PSBoundParameters.ContainsKey('AuditRuleInformation'))
+    {
+        foreach ($Instance in $AuditRuleInformation)
+        {
+            $AuditFlags = $Instance.CimInstanceProperties.Where({$_.Name -eq 'AuditFlags'}).ForEach({$_.Value})
+            $FileSystemRights = $Instance.CimInstanceProperties.Where({$_.Name -eq 'FileSystemRights'}).ForEach({$_.Value})
+            $Inheritance = $Instance.CimInstanceProperties.Where({$_.Name -eq 'Inheritance'}).ForEach({$_.Value})
+            $NoPropagateInherit = $Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
+
+            if (-not $AuditFlags)
+            {
+                $AuditFlags = 'Failure'
+            }
+
+            if (-not $FileSystemRights)
+            {
+                $FileSystemRights = 'ReadAndExecute'
+            }
+
+            if (-not $NoPropagateInherit)
+            {
+                $NoPropagateInherit = $false
+            }
+
+            $ReferenceRuleInfo += [PSCustomObject]@{
+                AuditFlags = $AuditFlags
+                FileSystemRights = $FileSystemRights
+                Inheritance = $Inheritance
+                NoPropagateInherit = $NoPropagateInherit
+            }
+        }
+    }
+    else
+    {
+        Write-Verbose -Message 'The AuditRuleInformation property is not specified.'
+
+        if ($Ensure -eq 'Present')
+        {
+            Write-Verbose -Message 'The default permission entry will be used as the reference permission entry.'
+
+            $ReferenceRuleInfo += [PSCustomObject]@{
+                AuditFlags = 'Failure'
+                FileSystemRights = 'ReadAndExecute'
+                Inheritance = $null
+                NoPropagateInherit = $false
+            }
+        }
+    }
+
+    if ($Ensure -eq 'Absent' -and $AuditRules.Count -ne 0)
+    {
+        if ($ReferenceRuleInfo.Count -ne 0)
+        {
+            $ReferenceRuleInfo |
+            ForEach-Object -Begin {$Counter = 0} -Process {
+
+                $Entry = $_
+
+                $ReferenceRule = New-FileSystemAuditRule `
+                    -ItemType $ItemType `
+                    -Principal $Identity.Name `
+                    -AuditFlags $Entry.AuditFlags `
+                    -FileSystemRights $Entry.FileSystemRights `
+                    -Inheritance $Entry.Inheritance `
+                    -NoPropagateInherit $Entry.NoPropagateInherit `
+                    -ErrorAction Stop
+
+                $MatchingRule = $AuditRules |
+                    Where-Object -FilterScript {
+                        ($_.AuditFlags -eq $ReferenceRule.AuditFlags) -and
+                        ($_.FileSystemRights -eq $ReferenceRule.FileSystemRights) -and
+                        ($_.InheritanceFlags -eq $ReferenceRule.InheritanceFlags) -and
+                        ($_.PropagationFlags -eq $ReferenceRule.PropagationFlags)
+                    }
+
+                if ($MatchingRule)
+                {
+                    ("Permission entry was found ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+                    ("> IdentityReference : '{0}'" -f $MatchingRule.IdentityReference),
+                    ("> AuditFlags        : '{0}'" -f $MatchingRule.AuditFlags),
+                    ("> FileSystemRights  : '{0}'" -f $MatchingRule.FileSystemRights),
+                    ("> InheritanceFlags  : '{0}'" -f $MatchingRule.InheritanceFlags),
+                    ("> PropagationFlags  : '{0}'" -f $MatchingRule.PropagationFlags) |
+                    Write-Verbose
+
+                    $InDesiredState = $false
+                }
+                else
+                {
+                    ("Permission entry was not found ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+                    ("> IdentityReference : '{0}'" -f $ReferenceRule.IdentityReference),
+                    ("> AuditFlags        : '{0}'" -f $ReferenceRule.AuditFlags),
+                    ("> FileSystemRights  : '{0}'" -f $ReferenceRule.FileSystemRights),
+                    ("> InheritanceFlags  : '{0}'" -f $ReferenceRule.InheritanceFlags),
+                    ("> PropagationFlags  : '{0}'" -f $ReferenceRule.PropagationFlags) |
+                    Write-Verbose
+                }
+
+            }
+        }
+        else
+        {
+            # All explicit permissions associated with the specified principal should be removed.
+            $InDesiredState = $false
+        }
+    }
+
+    if ($Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Desired permission entry count : $($ReferenceRuleInfo.Count)"
+
+        if ($AuditRules.Count -ne $ReferenceRuleInfo.Count)
+        {
+            Write-Verbose -Message 'The number of current permission entries is different from the number of desired permission entries.'
+
+            $InDesiredState = $false
+        }
+
+        $ReferenceRuleInfo |
+        ForEach-Object -Begin {$Counter = 0} -Process {
+
+            $Entry = $_
+
+            $ReferenceRule = New-FileSystemAuditRule `
+                -ItemType $ItemType `
+                -Principal $Identity.Name `
+                -AuditFlags $Entry.AuditFlags `
+                -FileSystemRights $Entry.FileSystemRights `
+                -Inheritance $Entry.Inheritance `
+                -NoPropagateInherit $Entry.NoPropagateInherit `
+                -ErrorAction Stop
+
+            $MatchingRule = $AuditRules |
+                Where-Object -FilterScript {
+                    ($_.AuditFlags -eq $ReferenceRule.AuditFlags) -and
+                    ($_.FileSystemRights -eq $ReferenceRule.FileSystemRights) -and
+                    ($_.InheritanceFlags -eq $ReferenceRule.InheritanceFlags) -and
+                    ($_.PropagationFlags -eq $ReferenceRule.PropagationFlags)
+                }
+
+            if ($MatchingRule)
+            {
+                ("Permission entry was found ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+                ("> IdentityReference : '{0}'" -f $MatchingRule.IdentityReference),
+                ("> AuditFlags        : '{0}'" -f $MatchingRule.AuditFlags),
+                ("> FileSystemRights  : '{0}'" -f $MatchingRule.FileSystemRights),
+                ("> InheritanceFlags  : '{0}'" -f $MatchingRule.InheritanceFlags),
+                ("> PropagationFlags  : '{0}'" -f $MatchingRule.PropagationFlags) |
+                Write-Verbose
+            }
+            else
+            {
+                ("Permission entry was not found ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+                ("> IdentityReference : '{0}'" -f $ReferenceRule.IdentityReference),
+                ("> AuditFlags        : '{0}'" -f $ReferenceRule.AuditFlags),
+                ("> FileSystemRights  : '{0}'" -f $ReferenceRule.FileSystemRights),
+                ("> InheritanceFlags  : '{0}'" -f $ReferenceRule.InheritanceFlags),
+                ("> PropagationFlags  : '{0}'" -f $ReferenceRule.PropagationFlags) |
+                Write-Verbose
+
+                $InDesiredState = $false
+            }
+
+        }
+    }
+
+    if ($InDesiredState -eq $true)
+    {
+        Write-Verbose -Message 'The target resource is already in the desired state. No action is required.'
+    }
+    else
+    {
+        Write-Verbose -Message 'The target resource is not in the desired state.'
+    }
+
+    return $InDesiredState
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Absent', 'Present')]
+        [String]
+        $Ensure = 'Present',
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Directory', 'File')]
+        [String]
+        $ItemType,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Principal,
+
+        [Parameter(Mandatory = $false)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AuditRuleInformation
+    )
+
+    $Acl = Get-Acl -Path $Path -Audit -ErrorAction Stop
+
+    if ($Acl -is [System.Security.AccessControl.DirectorySecurity])
+    {
+        $ItemType = 'Directory'
+    }
+    else
+    {
+        $ItemType = 'File'
+    }
+
+    $Identity = Resolve-IdentityReference -Identity $Principal -ErrorAction Stop
+
+    [System.Security.AccessControl.FileSystemAuditRule[]]$AuditRules = @(
+        $Acl.Audit |
+        Where-Object -FilterScript {
+            ($_.IsInherited -eq $false) -and
+            ($_.IdentityReference -eq $Identity.Name)
+        }
+    )
+
+    Write-Verbose -Message "Current permission entry count : $($AuditRules.Count)"
+
+    [PSCustomObject[]]$ReferenceRuleInfo = @()
+
+    if ($PSBoundParameters.ContainsKey('AuditRuleInformation'))
+    {
+        foreach ($Instance in $AuditRuleInformation)
+        {
+            $AuditFlags = $Instance.CimInstanceProperties.Where({$_.Name -eq 'AuditFlags'}).ForEach({$_.Value})
+            $FileSystemRights = $Instance.CimInstanceProperties.Where({$_.Name -eq 'FileSystemRights'}).ForEach({$_.Value})
+            $Inheritance = $Instance.CimInstanceProperties.Where({$_.Name -eq 'Inheritance'}).ForEach({$_.Value})
+            $NoPropagateInherit = $Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
+
+            if (-not $AuditFlags)
+            {
+                $AuditFlags = 'Failure'
+            }
+
+            if (-not $FileSystemRights)
+            {
+                $FileSystemRights = 'ReadAndExecute'
+            }
+
+            if (-not $NoPropagateInherit)
+            {
+                $NoPropagateInherit = $false
+            }
+
+            $ReferenceRuleInfo += [PSCustomObject]@{
+                AuditFlags = $AuditFlags
+                FileSystemRights = $FileSystemRights
+                Inheritance = $Inheritance
+                NoPropagateInherit = $NoPropagateInherit
+            }
+        }
+    }
+    else
+    {
+        Write-Verbose -Message 'The AuditRuleInformation property is not specified.'
+
+        if ($Ensure -eq 'Present')
+        {
+            Write-Verbose -Message 'The default permission entry will be added.'
+
+            $ReferenceRuleInfo += [PSCustomObject]@{
+                AccessControlType = 'Failure'
+                FileSystemRights = 'ReadAndExecute'
+                Inheritance = $null
+                NoPropagateInherit = $false
+            }
+        }
+    }
+
+    if ($Ensure -eq 'Absent' -and $AuditRules.Count -ne 0)
+    {
+        if ($ReferenceRuleInfo.Count -ne 0)
+        {
+            $ReferenceRuleInfo |
+            ForEach-Object -Begin {$Counter = 0} -Process {
+
+                $Entry = $_
+
+                $ReferenceRule = New-FileSystemAuditRule `
+                    -ItemType $ItemType `
+                    -Principal $Identity.Name `
+                    -AuditFlags $Entry.AuditFlags `
+                    -FileSystemRights $Entry.FileSystemRights `
+                    -Inheritance $Entry.Inheritance `
+                    -NoPropagateInherit $Entry.NoPropagateInherit `
+                    -ErrorAction Stop
+
+                $MatchingRule = $AuditRules |
+                    Where-Object -FilterScript {
+                        ($_.AuditFlags -eq $ReferenceRule.AuditFlags) -and
+                        ($_.FileSystemRights -eq $ReferenceRule.FileSystemRights) -and
+                        ($_.InheritanceFlags -eq $ReferenceRule.InheritanceFlags) -and
+                        ($_.PropagationFlags -eq $ReferenceRule.PropagationFlags)
+                    }
+
+                if ($MatchingRule)
+                {
+                    ("Removing permission entry ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+                    ("> IdentityReference : '{0}'" -f $MatchingRule.IdentityReference),
+                    ("> AuditFlags : '{0}'" -f $MatchingRule.AuditFlags),
+                    ("> FileSystemRights  : '{0}'" -f $MatchingRule.FileSystemRights),
+                    ("> InheritanceFlags  : '{0}'" -f $MatchingRule.InheritanceFlags),
+                    ("> PropagationFlags  : '{0}'" -f $MatchingRule.PropagationFlags) |
+                    Write-Verbose
+
+                    $Modified = $null
+                    $Acl.ModifyAuditRule('RemoveSpecific', $MatchingRule, [Ref]$Modified)
+                }
+            }
+        }
+        else
+        {
+            "Removing all explicit permissions for principal '{0}'." -f $($AuditRules[0].IdentityReference) |
+            Write-Verbose
+
+            $Modified = $null
+            $Acl.ModifyAuditRule('RemoveAll', $AuditRules[0], [Ref]$Modified)
+        }
+    }
+
+    if ($Ensure -eq 'Present')
+    {
+        if ($AuditRules.Count -ne 0)
+        {
+            "Removing all explicit permissions for principal '{0}'." -f $($AuditRules[0].IdentityReference) |
+            Write-Verbose
+
+            $Modified = $null
+            $Acl.ModifyAuditRule('RemoveAll', $AuditRules[0], [Ref]$Modified)
+        }
+
+        $ReferenceRuleInfo |
+        ForEach-Object -Begin {$Counter = 0} -Process {
+
+            $Entry = $_
+
+            $ReferenceRule = New-FileSystemAuditRule `
+                -ItemType $ItemType `
+                -Principal $Identity.Name `
+                -AuditFlags $Entry.AuditFlags `
+                -FileSystemRights $Entry.FileSystemRights `
+                -Inheritance $Entry.Inheritance `
+                -NoPropagateInherit $Entry.NoPropagateInherit `
+                -ErrorAction Stop
+
+            ("Adding permission entry ({0} of {1}) :" -f (++$Counter), $ReferenceRuleInfo.Count),
+            ("> IdentityReference : '{0}'" -f $ReferenceRule.IdentityReference),
+            ("> AuditFlags : '{0}'" -f $ReferenceRule.AuditFlags),
+            ("> FileSystemRights  : '{0}'" -f $ReferenceRule.FileSystemRights),
+            ("> InheritanceFlags  : '{0}'" -f $ReferenceRule.InheritanceFlags),
+            ("> PropagationFlags  : '{0}'" -f $ReferenceRule.PropagationFlags) |
+            Write-Verbose
+
+            $Acl.AddAuditRule($ReferenceRule)
+
+        }
+    }
+
+    Set-FileSystemAccessControl -Path $Path -Acl $Acl
+
+}
+
+#region Helper Functions
+
+function ConvertFrom-FileSystemAuditRule
+{
+    <#
+    .SYNOPSIS
+        Converts a FileSystemAccessRule object to a custom object.
+
+    .DESCRIPTION
+        The ConvertFrom-FileSystemAuditRule function converts a FileSystemAuditRule object to a custom object.
+
+    .PARAMETER ItemType
+        Specifies whether the item is a directory or a file.
+
+    .PARAMETER InputObject
+        Specifies the FileSystemAuditRule object to convert.
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Directory', 'File')]
+        [String]
+        $ItemType,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Security.AccessControl.FileSystemAuditRule]
+        $InputObject
+    )
+    process
+    {
+        [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = $InputObject.InheritanceFlags
+        [System.Security.AccessControl.PropagationFlags]$PropagationFlags = $InputObject.PropagationFlags
+
+        $NoPropagateInherit = $PropagationFlags.HasFlag([System.Security.AccessControl.PropagationFlags]::NoPropagateInherit)
+
+        if ($NoPropagateInherit)
+        {
+            [System.Security.AccessControl.PropagationFlags]$PropagationFlags =
+                $PropagationFlags -bxor [System.Security.AccessControl.PropagationFlags]::NoPropagateInherit
+        }
+
+        if ($InheritanceFlags -eq 'None' -and $PropagationFlags -eq 'None')
+        {
+            if ($ItemType -eq 'Directory')
+            {
+                $Inheritance = 'ThisFolderOnly'
+            }
+            else
+            {
+                $Inheritance = 'None'
+            }
+        }
+        elseif ($InheritanceFlags -eq 'ContainerInherit, ObjectInherit' -and $PropagationFlags -eq 'None')
+        {
+            $Inheritance = 'ThisFolderSubfoldersAndFiles'
+        }
+        elseif ($InheritanceFlags -eq 'ContainerInherit' -and $PropagationFlags -eq 'None')
+        {
+            $Inheritance = 'ThisFolderAndSubfolders'
+        }
+        elseif ($InheritanceFlags -eq 'ObjectInherit' -and $PropagationFlags -eq 'None')
+        {
+            $Inheritance = 'ThisFolderAndFiles'
+        }
+        elseif ($InheritanceFlags -eq 'ContainerInherit, ObjectInherit' -and $PropagationFlags -eq 'InheritOnly')
+        {
+            $Inheritance = 'SubfoldersAndFilesOnly'
+        }
+        elseif ($InheritanceFlags -eq 'ContainerInherit' -and $PropagationFlags -eq 'InheritOnly')
+        {
+            $Inheritance = 'SubfoldersOnly'
+        }
+        elseif ($InheritanceFlags -eq 'ObjectInherit' -and $PropagationFlags -eq 'InheritOnly')
+        {
+            $Inheritance = 'FilesOnly'
+        }
+
+        $OutputObject = [PSCustomObject]@{
+            ItemType = $ItemType
+            Principal = [String]$InputObject.IdentityReference
+            AuditFlags = [String]$InputObject.AuditFlags
+            FileSystemRights = [String]$InputObject.FileSystemRights
+            Inheritance = $Inheritance
+            NoPropagateInherit = $NoPropagateInherit
+        }
+
+        return $OutputObject
+    }
+}
+
+function New-FileSystemAuditRule
+{
+    <#
+    .SYNOPSIS
+        Creates a FileSystemAuditRule object.
+
+    .DESCRIPTION
+        The New-FileSystemAuditRule function creates a FileSystemAccessRule object
+        that represents an abstraction of an access control entry (ACE).
+
+    .PARAMETER ItemType
+        Specifies whether the item is a directory or a file.
+
+    .PARAMETER Principal
+        Specifies the identity of the principal.
+
+    .PARAMETER AccessControlType
+        Specifies whether the ACE to be used to allow or deny access.
+
+    .PARAMETER FileSystemRights
+        Specifies the access rights to be granted to the principal.
+
+    .PARAMETER Inheritance
+        Specifies the inheritance type of the ACE.
+
+    .PARAMETER NoPropagateInherit
+        Specifies that the ACE is not propagated to child objects.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Security.AccessControl.FileSystemAccessRule])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet('Directory', 'File')]
+        [String]
+        $ItemType,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]
+        $Principal,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet('Success', 'Failure', 'None', 'All')]
+        [String]
+        $AuditFlags,
+
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.Security.AccessControl.FileSystemRights]
+        $FileSystemRights,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet(
+            $null,
+            'None',
+            'ThisFolderOnly',
+            'ThisFolderSubfoldersAndFiles',
+            'ThisFolderAndSubfolders',
+            'ThisFolderAndFiles',
+            'SubfoldersAndFilesOnly',
+            'SubfoldersOnly',
+            'FilesOnly'
+        )]
+        [String]
+        $Inheritance = 'ThisFolderSubfoldersAndFiles',
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Boolean]
+        $NoPropagateInherit = $false
+    )
+    process
+    {
+        if ($ItemType -eq 'Directory')
+        {
+            switch ($Inheritance)
+            {
+                {$_ -in @('None', 'ThisFolderOnly')}
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'None'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+                }
+
+                'ThisFolderSubfoldersAndFiles'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ContainerInherit', 'ObjectInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+                }
+
+                'ThisFolderAndSubfolders'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ContainerInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+                }
+
+                'ThisFolderAndFiles'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ObjectInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+                }
+
+                'SubfoldersAndFilesOnly'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ContainerInherit', 'ObjectInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'InheritOnly'
+                }
+
+                'SubfoldersOnly'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ContainerInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'InheritOnly'
+                }
+
+                'FilesOnly'
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ObjectInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'InheritOnly'
+                }
+
+                default
+                {
+                    [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'ContainerInherit', 'ObjectInherit'
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+                }
+            }
+
+            if ($NoPropagateInherit -eq $true -and $InheritanceFlags -ne 'None')
+            {
+                [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'NoPropagateInherit'
+            }
+        }
+        else
+        {
+            [System.Security.AccessControl.InheritanceFlags]$InheritanceFlags = 'None'
+            [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'None'
+        }
+
+        Switch ($AuditFlags) {
+            'Success' {
+                $Flags = [System.Security.AccessControl.AuditFlags]::Success
+            }
+
+            'Failure' {
+                $Flags = [System.Security.AccessControl.AuditFlags]::Failure
+            }
+
+            'None' {
+                $Flags = [System.Security.AccessControl.AuditFlags]::None
+            }
+
+            'All' {
+                $Flags = @([System.Security.AccessControl.AuditFlags]::Success,[System.Security.AccessControl.AuditFlags]::Failure)
+            }
+            
+        }
+
+        $OutputObject = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+            -ArgumentList $Principal, $FileSystemRights, $InheritanceFlags, $PropagationFlags, $Flags
+
+        return $OutputObject
+    }
+}
+
+function Set-FileSystemAccessControl
+{
+    <#
+    .SYNOPSIS
+        Applies access control entries (ACEs) to the specified file or directory.
+
+    .DESCRIPTION
+        The Set-FileSystemAccessControl function applies access control entries (ACEs) to the specified file or directory.
+
+    .PARAMETER Path
+        Specifies the path to the file or directory.
+
+    .PARAMETER Acl
+        Specifies the access control list (ACL) object with the desired access control entries (ACEs)
+        to apply to the file or directory described by the Path parameter.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({Test-Path -Path $_})]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Security.AccessControl.FileSystemSecurity]
+        $Acl
+    )
+
+    $PathInfo = Resolve-Path -Path $Path -ErrorAction Stop
+
+    if ($PSCmdlet.ShouldProcess($Path))
+    {
+        if ($Acl -is [System.Security.AccessControl.DirectorySecurity])
+        {
+            [System.IO.Directory]::SetAccessControl($PathInfo.ProviderPath, $Acl)
+        }
+        else
+        {
+            [System.IO.File]::SetAccessControl($PathInfo.ProviderPath, $Acl)
+        }
+    }
+}
+
+function Resolve-IdentityReference
+{
+    <#
+    .SYNOPSIS
+        Resolves the identity of the principal.
+
+    .DESCRIPTION
+        The Resolve-IdentityReference function resolves the identity of the principal
+        and returns its down-level logon name and security identifier (SID).
+
+    .PARAMETER Identity
+        Specifies the identity of the principal.
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Identity
+    )
+    process
+    {
+        try
+        {
+            Write-Verbose -Message "Resolving identity reference '$Identity'."
+
+            if ($Identity -match '^S-\d-(\d+-){1,14}\d+$')
+            {
+                [System.Security.Principal.SecurityIdentifier]$Identity = $Identity
+            }
+            else
+            {
+                [System.Security.Principal.NTAccount]$Identity = $Identity
+            }
+
+            $SID = $Identity.Translate([System.Security.Principal.SecurityIdentifier])
+            $NTAccount = $SID.Translate([System.Security.Principal.NTAccount])
+
+            $OutputObject = [PSCustomObject]@{
+                Name = $NTAccount.Value
+                SID = $SID.Value
+            }
+
+            return $OutputObject
+        }
+        catch
+        {
+            $ErrorMessage = "Could not resolve identity reference '{0}': '{1}'." -f $Identity, $_.Exception.Message
+            Write-Error -Exception $_.Exception -Message $ErrorMessage
+            return
+        }
+    }
+}
+
+#endregion

--- a/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.schema.mof
+++ b/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.schema.mof
@@ -1,0 +1,18 @@
+[ClassVersion("1.1.0.0")]
+class cNtfsAuditRuleInformation
+{
+    [Write, Description("Indicates whether to allow or deny access to the target item."), ValueMap{"Success","Failure","All","None"}, Values{"Success","Failure","All","None"}] String AuditFlags;
+    [Write, Description("Indicates the access rights to be granted to the principal.")] String FileSystemRights[];
+    [Write, Description("Indicates the inheritance type of the permission entry."), ValueMap{"None","ThisFolderOnly","ThisFolderSubfoldersAndFiles","ThisFolderAndSubfolders","ThisFolderAndFiles","SubfoldersAndFilesOnly","SubfoldersOnly","FilesOnly"}, Values{"None","ThisFolderOnly","ThisFolderSubfoldersAndFiles","ThisFolderAndSubfolders","ThisFolderAndFiles","SubfoldersAndFilesOnly","SubfoldersOnly","FilesOnly"}] String Inheritance;
+    [Write, Description("Indicates whether the permission entry is not propagated to child objects.")] Boolean NoPropagateInherit;
+};
+
+[ClassVersion("1.1.0.0"), FriendlyName("cNtfsAuditEntry")]
+class cNtfsAuditEntry : OMI_BaseResource
+{
+    [Write, Description("Indicates if the principal has explicitly assigned permissions on the target path."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] String Ensure;
+    [Key, Description("Indicates the path to the target item.")] String Path;
+    [Write, Description("Obsolete. Indicates whether the target item is a Directory or a File."), ValueMap{"Directory","File"}, Values{"Directory","File"}] String ItemType;
+    [Key, Description("Indicates the identity of the principal.")] String Principal;
+    [Write, Description("Indicates the access control information in the form of an array of instances of the cNtfsAuditRuleInformation CIM class."), EmbeddedInstance("cNtfsAuditRuleInformation")] String AuditRuleInformation[];
+};

--- a/DSCResources/cNtfsAuditInheritance/cNtfsAuditInheritance.psm1
+++ b/DSCResources/cNtfsAuditInheritance/cNtfsAuditInheritance.psm1
@@ -1,0 +1,181 @@
+#requires -Version 4.0
+
+Set-StrictMode -Version Latest
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $Enabled = $true,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $PreserveInherited = $true
+    )
+
+    $PSBoundParameters.GetEnumerator() |
+    ForEach-Object -Begin {
+        $Width = $PSBoundParameters.Keys.Length | Sort-Object | Select-Object -Last 1
+    } -Process {
+        "{0,-$($Width)} : '{1}'" -f $_.Key, ($_.Value -join ', ') |
+        Write-Verbose
+    }
+
+    $Acl = Get-Acl -Path $Path -Audit -ErrorAction Stop
+
+    $EnabledResult = $Acl.AreAuditRulesProtected -eq $false
+
+    if ($EnabledResult -eq $true)
+    {
+        Write-Verbose -Message "Permissions inheritance is enabled on path '$Path'."
+    }
+    else
+    {
+        Write-Verbose -Message "Permissions inheritance is disabled on path '$Path'."
+    }
+
+    $ReturnValue = @{
+        Path = $Path
+        Enabled = $EnabledResult
+        PreserveInherited = $PreserveInherited
+    }
+
+    return $ReturnValue
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $Enabled = $true,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $PreserveInherited = $true
+    )
+
+    $TargetResource = Get-TargetResource @PSBoundParameters
+
+    $InDesiredState = $Enabled -eq $TargetResource.Enabled
+
+    if ($InDesiredState -eq $true)
+    {
+        Write-Verbose -Message 'The target resource is already in the desired state. No action is required.'
+    }
+    else
+    {
+        Write-Verbose -Message 'The target resource is not in the desired state.'
+    }
+
+    return $InDesiredState
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $Enabled = $true,
+
+        [Parameter(Mandatory = $false)]
+        [Boolean]
+        $PreserveInherited = $true
+    )
+
+    $Acl = Get-Acl -Path $Path -Audit -ErrorAction Stop
+
+    if ($Enabled -eq $false)
+    {
+        Write-Verbose -Message "Disabling permissions inheritance on path '$Path'."
+
+        if ($PreserveInherited -eq $true)
+        {
+            Write-Verbose -Message 'Inherited permissions will be converted into explicit permissions.'
+        }
+        else
+        {
+            Write-Verbose -Message 'Inherited permissions will be removed.'
+        }
+
+        $Acl.SetAuditRuleProtection($true, $PreserveInherited)
+    }
+    else
+    {
+        Write-Verbose -Message "Enabling permissions inheritance on path '$Path'."
+
+        $Acl.SetAuditRuleProtection($false, $false)
+    }
+
+    Set-FileSystemAccessControl -Path $Path -Acl $Acl
+}
+
+#region Helper Functions
+
+function Set-FileSystemAccessControl
+{
+    <#
+    .SYNOPSIS
+        Applies access control entries (ACEs) to the specified file or directory.
+
+    .DESCRIPTION
+        The Set-FileSystemAccessControl function applies access control entries (ACEs) to the specified file or directory.
+
+    .PARAMETER Path
+        Specifies the path to the file or directory.
+
+    .PARAMETER Acl
+        Specifies the access control list (ACL) object with the desired access control entries (ACEs)
+        to apply to the file or directory described by the Path parameter.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({Test-Path -Path $_})]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Security.AccessControl.FileSystemSecurity]
+        $Acl
+    )
+
+    $PathInfo = Resolve-Path -Path $Path -ErrorAction Stop
+
+    if ($PSCmdlet.ShouldProcess($Path))
+    {
+        if ($Acl -is [System.Security.AccessControl.DirectorySecurity])
+        {
+            [System.IO.Directory]::SetAccessControl($PathInfo.ProviderPath, $Acl)
+        }
+        else
+        {
+            [System.IO.File]::SetAccessControl($PathInfo.ProviderPath, $Acl)
+        }
+    }
+}
+
+#endregion

--- a/DSCResources/cNtfsAuditInheritance/cNtfsAuditInheritance.schema.mof
+++ b/DSCResources/cNtfsAuditInheritance/cNtfsAuditInheritance.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0.0"), FriendlyName("cNtfsAuditInheritance")]
+class cNtfsAuditInheritance : OMI_BaseResource
+{
+    [Key, Description("Indicates the path to the target item.")] String Path;
+    [Write, Description("Indicates whether NTFS permissions inheritance is enabled.")] Boolean Enabled;
+    [Write, Description("Indicates whether to preserve inherited permissions.")] Boolean PreserveInherited;
+};

--- a/Tests/Unit/cNtfsAuditEntry.Tests.ps1
+++ b/Tests/Unit/cNtfsAuditEntry.Tests.ps1
@@ -1,0 +1,1625 @@
+#requires -Version 4.0 -Modules Pester, CimCmdlets
+
+$Global:DSCModuleName   = 'cNtfsAccessControl'
+$Global:DSCResourceName = 'cNtfsAuditEntry'
+
+#region Header
+
+$ModuleRoot = Split-Path -Path $Script:MyInvocation.MyCommand.Path -Parent | Split-Path -Parent | Split-Path -Parent
+
+if (
+    (-not (Test-Path -Path (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests') -PathType Container)) -or
+    (-not (Test-Path -Path (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -PathType Leaf))
+)
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit
+
+#endregion
+
+try
+{
+    #region Unit Tests
+
+    InModuleScope $Global:DSCResourceName {
+
+        #region Helper Functions
+
+        function Set-NewTempItemAcl
+        {
+            <#
+            .SYNOPSIS
+                Creates a new temporary directory or file and sets its Access Control List (ACL).
+
+            .DESCRIPTION
+                The Set-NewTempItemAcl function creates a new temporary directory or file and sets its Access Control List (ACL):
+                - Disables NTFS permissions inheritance.
+                - Removes all permission entries.
+                - Grants Full Control permission to the calling user to ensure the file can be removed later.
+                - Optionally adds additional permission entries.
+            #>
+            [CmdletBinding()]
+            param
+            (
+                [Parameter(Mandatory = $false)]
+                [ValidateSet('Directory', 'File')]
+                [String]
+                $ItemType = 'Directory',
+
+                [Parameter(Mandatory = $false)]
+                [ValidateNotNullOrEmpty()]
+                [String]
+                $Path = (Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())),
+
+                [Parameter(Mandatory = $false)]
+                [System.Security.AccessControl.FileSystemAuditRule[]]
+                $AuditRulesToAdd,
+
+                [Parameter(Mandatory = $false)]
+                [Switch]
+                $PassThru
+            )
+
+            try
+            {
+                $TempItem = New-Item -Path $Path -ItemType $ItemType -Force -ErrorAction Stop -Verbose:$VerbosePreference
+                $Acl = $TempItem.GetAccessControl()
+
+                $Acl.SetAuditRuleProtection($true, $false)
+                #$Acl.Audit.ForEach({[Void]$Acl.RemoveAuditRule($_)})
+
+                $CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+                if ($ItemType -eq 'Directory')
+                {
+                    $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $CurrentUser,
+                            'FullControl',
+                            @('ContainerInherit',
+                            'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+                }
+                else
+                {
+                    $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $CurrentUser,
+                            'FullControl',
+                            'None',
+                            'None',
+                            'Sucess'
+                        )
+                }
+
+                $Acl.AddAuditRule($DefaultAuditRule)
+
+                if ($PSBoundParameters.ContainsKey('AuditRulesToAdd'))
+                {
+                    $AuditRulesToAdd.ForEach({$Acl.AddAuditRule($_)})
+                }
+
+                if ($ItemType -eq 'Directory')
+                {
+                    [System.IO.Directory]::SetAccessControl($TempItem.FullName, $Acl)
+                }
+                else
+                {
+                    [System.IO.File]::SetAccessControl($TempItem.FullName, $Acl)
+                }
+
+                if ($PassThru)
+                {
+                    return $TempItem
+                }
+            }
+            catch
+            {
+                throw
+            }
+        }
+
+        #endregion
+
+        Describe "$Global:DSCResourceName\Get-TargetResource" {
+
+            Context 'Permissions exist' {
+
+                $ContextParams = @{
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                $Result = Get-TargetResource @ContextParams
+
+                It 'Should return Ensure set to Present' {
+                    $Result.Ensure | Should Be 'Present'
+                }
+
+                It 'Should return Path' {
+                    $Result.Path | Should Be $ContextParams.Path
+                }
+
+                It 'Should return Principal' {
+                    $Result.Principal | Should Be $ContextParams.Principal
+                }
+
+                It 'Should return AuditRuleInformation' {
+                    $Result.AuditRuleInformation.Count | Should Be 3
+                }
+
+            }
+
+            Context 'No permissions exist' {
+
+                $ContextParams = @{
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                $Result = Get-TargetResource @ContextParams
+
+                It 'Should return Ensure set to Absent' {
+                    $Result.Ensure | Should Be 'Absent'
+                }
+
+                It 'Should return Path' {
+                    $Result.Path | Should Be $ContextParams.Path
+                }
+
+                It 'Should return Principal' {
+                    $Result.Principal | Should Be $ContextParams.Principal
+                }
+
+                It 'Should return empty AuditRuleInformation' {
+                    $Result.AuditRuleInformation.Count | Should Be 0
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Test-TargetResource behavior with Ensure set to Absent" {
+
+            Context 'AuditControlInformation is not specified, no permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                It 'Should return True' {
+                    Test-TargetResource @ContextParams | Should Be $true
+                }
+
+            }
+
+            Context 'AuditControlInformation is not specified, permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, no matching permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return True' {
+                    Test-TargetResource @ContextParams | Should Be $true
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, matching permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Test-TargetResource behavior with Ensure set to Present" {
+
+            Context 'AuditRuleInformation is not specified, no permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is not specified, default permission exists, no other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $ContextParams.Principal,
+                        'ReadAndExecute',
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        'Failure'
+                    )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $DefaultAuditRule
+
+                It 'Should return True' {
+                    Test-TargetResource @ContextParams | Should Be $true
+                }
+
+            }
+
+            Context 'AuditRuleInformation is not specified, default permission exists, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $ContextParams.Principal,
+                        'ReadAndExecute',
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        'Failure'
+                    )
+
+                $TempAuditRules = @(
+
+                    $DefaultAuditRule
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is not specified, no default permission exists, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, no permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'CreateFiles', 'AppendData'
+                                Inheritance = 'SubfoldersAndFilesOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, desired permissions exist, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return False' {
+                    Test-TargetResource @ContextParams | Should Be $false
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, permissions exist and match the desired state' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'CreateFiles', 'AppendData'
+                                Inheritance = 'SubfoldersAndFilesOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should return True' {
+                    Test-TargetResource @ContextParams | Should Be $true
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Set-TargetResource behavior with Ensure set to Absent" {
+
+            Context 'AuditRuleInformation is not specified, permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should remove all permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $TempAuditRules.Count
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be 0
+
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, matching permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Absent'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should remove matching permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $TempAuditRules.Count
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be ($TempAuditRules.Count - $ContextParams.AuditRuleInformation.Count)
+
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Set-TargetResource behavior with Ensure set to Present" {
+
+            Context 'AuditRuleInformation is not specified, no permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $ContextParams.Principal,
+                        'ReadAndExecute',
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        'Failure'
+                    )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                It 'Should add the default permission' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be 0
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    $AccessRules = @(
+                        (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                            {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                        )
+                    )
+
+                    $AccessRules.Count | Should Be 1
+                    $AccessRules[0].FileSystemRights | Should Be $DefaultAuditRule.FileSystemRights
+                    $AccessRules[0].AuditFlags | Should Be $DefaultAuditRule.AuditFlags
+                    $AccessRules[0].InheritanceFlags | Should Be $DefaultAuditRule.InheritanceFlags
+                    $AccessRules[0].PropagationFlags | Should Be $DefaultAuditRule.PropagationFlags
+                }
+
+            }
+
+            Context 'AuditRuleInformation is not specified, default permission exists, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $ContextParams.Principal,
+                        'ReadAndExecute',
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        'Failure'
+                    )
+
+                $TempAuditRules = @(
+
+                    $DefaultAuditRule
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should remove other permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $TempAuditRules.Count
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    $AccessRules = @(
+                        (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                            {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                        )
+                    )
+
+                    $AccessRules.Count | Should Be 1
+                    $AccessRules[0].FileSystemRights | Should Be $DefaultAuditRule.FileSystemRights
+                    $AccessRules[0].AuditFlags | Should Be $DefaultAuditRule.AuditFlags
+                    $AccessRules[0].InheritanceFlags | Should Be $DefaultAuditRule.InheritanceFlags
+                    $AccessRules[0].PropagationFlags | Should Be $DefaultAuditRule.PropagationFlags
+
+                }
+
+            }
+
+            Context 'AuditRuleInformation is not specified, no default permission exists, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                }
+
+                $DefaultAuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $ContextParams.Principal,
+                        'ReadAndExecute',
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        'Failure'
+                    )
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should add the default permission and remove other permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $TempAuditRules.Count
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    $AccessRules = @(
+                        (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                            {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                        )
+                    )
+
+                    $AccessRules.Count | Should Be 1
+                    $AccessRules[0].FileSystemRights | Should Be $DefaultAuditRule.FileSystemRights
+                    $AccessRules[0].AuditFlags | Should Be $DefaultAuditRule.AuditFlags
+                    $AccessRules[0].InheritanceFlags | Should Be $DefaultAuditRule.InheritanceFlags
+                    $AccessRules[0].PropagationFlags | Should Be $DefaultAuditRule.PropagationFlags
+
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, no permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'CreateFiles', 'AppendData'
+                                Inheritance = 'SubfoldersAndFilesOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path
+
+                It 'Should add the desired permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be 0
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $ContextParams.AuditRuleInformation.Count
+
+                }
+
+            }
+
+            Context 'AuditRuleInformation is specified, desired permissions exist, other permissions exist' {
+
+                $ContextParams = @{
+                    Ensure = 'Present'
+                    Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                    Principal = 'BUILTIN\Users'
+                    AuditRuleInformation = @(
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'ReadAndExecute'
+                                Inheritance = 'ThisFolderSubfoldersAndFiles'
+                                NoPropagateInherit = $false
+                            }
+
+                        New-CimInstance -ClientOnly `
+                            -Namespace root/Microsoft/Windows/DesiredStateConfiguration `
+                            -ClassName cNtfsAuditRuleInformation `
+                            -Property @{
+                                AuditFlags = 'Failure'
+                                FileSystemRights = 'Modify'
+                                Inheritance = 'ThisFolderOnly'
+                                NoPropagateInherit = $false
+                            }
+
+                    )
+                }
+
+                $TempAuditRules = @(
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'ReadAndExecute',
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            'Modify',
+                            'None',
+                            'None',
+                            'Failure'
+                        )
+
+                    New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                        -ArgumentList @(
+                            $ContextParams.Principal,
+                            @('CreateFiles', 'AppendData'),
+                            @('ContainerInherit', 'ObjectInherit'),
+                            'InheritOnly',
+                            'Failure'
+                        )
+
+                )
+
+                Set-NewTempItemAcl -ItemType Directory -Path $ContextParams.Path -AuditRulesToAdd $TempAuditRules
+
+                It 'Should remove other permissions' {
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $TempAuditRules.Count
+
+                    Test-TargetResource @ContextParams | Should Be $false
+
+                    Set-TargetResource @ContextParams
+
+                    Test-TargetResource @ContextParams | Should Be $true
+
+                    (Get-Acl -Path $ContextParams.Path -Audit).Audit.Where(
+                        {$_.IsInherited -eq $false -and $_.IdentityReference -eq $ContextParams.Principal}
+                    ).Count |
+                    Should Be $ContextParams.AuditRuleInformation.Count
+
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\ConvertFrom-FileSystemAuditRule" {
+
+            $DescribeParams = @{
+                Principal = 'BUILTIN\Users'
+                AuditFlags = 'Failure'
+                FileSystemRights = @('ReadAndExecute', 'Write', 'Synchronize')
+            }
+
+            Context 'PropagationFlags has the NoPropagateInherit flag set' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'NoPropagateInherit',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return NoPropagateInherit set to True' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'ThisFolderSubfoldersAndFiles'
+                    $Result.NoPropagateInherit | Should Be $true
+                }
+
+            }
+
+            Context 'InheritanceFlags is None and PropagationFlags is None' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        'None',
+                        'None',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to ThisFolderOnly if ItemType is Directory' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'ThisFolderOnly'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+                It 'Should return Inheritance set to None if ItemType is File' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType File -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'None'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is "ContainerInherit, ObjectInherit" and PropagationFlags is None' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'None',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to ThisFolderSubfoldersAndFiles' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'ThisFolderSubfoldersAndFiles'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is ContainerInherit and PropagationFlags is None' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        'ContainerInherit',
+                        'None',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to ThisFolderAndSubfolders' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'ThisFolderAndSubfolders'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is ObjectInherit and PropagationFlags is None' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        'ObjectInherit',
+                        'None',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to ThisFolderAndFiles' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'ThisFolderAndFiles'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is "ContainerInherit, ObjectInherit" and PropagationFlags is InheritOnly' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        @('ContainerInherit', 'ObjectInherit'),
+                        'InheritOnly',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to SubfoldersAndFilesOnly' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'SubfoldersAndFilesOnly'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is ContainerInherit and PropagationFlags is InheritOnly' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        'ContainerInherit',
+                        'InheritOnly',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to SubfoldersOnly' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'SubfoldersOnly'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+            Context 'InheritanceFlags is ObjectInherit and PropagationFlags is InheritOnly' {
+
+                $AccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $DescribeParams.Principal,
+                        $DescribeParams.FileSystemRights,
+                        'ObjectInherit',
+                        'InheritOnly',
+                        $DescribeParams.AuditFlags
+                    )
+
+                It 'Should return Inheritance set to FilesOnly' {
+                    $Result = ConvertFrom-FileSystemAuditRule -ItemType Directory -InputObject $AccessRule
+                    $Result.Inheritance | Should Be 'FilesOnly'
+                    $Result.NoPropagateInherit | Should Be $false
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\New-FileSystemAuditRule" {
+
+            $DescribeParams = @{
+                Principal = 'BUILTIN\Users'
+                AuditFlags = 'Failure'
+                FileSystemRights = @('ReadAndExecute', 'Write')
+            }
+
+            Context 'ItemType is Directory and NoPropagateInherit is False' {
+
+                $ContextParams = $DescribeParams.Clone()
+                $ContextParams.Add('ItemType', 'Directory')
+                $ContextParams.Add('NoPropagateInherit', $false)
+
+                It 'Inheritance is Null' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance $null
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is None' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance None
+                    $Result.InheritanceFlags | Should Be 'None'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderOnly
+                    $Result.InheritanceFlags | Should Be 'None'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderSubfoldersAndFiles' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderSubfoldersAndFiles
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderAndSubfolders' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderAndSubfolders
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderAndFiles' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderAndFiles
+                    $Result.InheritanceFlags | Should Be 'ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is SubfoldersAndFilesOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance SubfoldersAndFilesOnly
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'InheritOnly'
+                }
+
+                It 'Inheritance is SubfoldersOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance SubfoldersOnly
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit'
+                    $Result.PropagationFlags | Should Be 'InheritOnly'
+                }
+
+                It 'Inheritance is FilesOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance FilesOnly
+                    $Result.InheritanceFlags | Should Be 'ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'InheritOnly'
+                }
+
+            }
+
+            Context 'ItemType is Directory and NoPropagateInherit is True' {
+
+                $ContextParams = $DescribeParams.Clone()
+                $ContextParams.Add('ItemType', 'Directory')
+                $ContextParams.Add('NoPropagateInherit', $true)
+
+                It 'Inheritance is Null' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance $null
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is None' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance None
+                    $Result.InheritanceFlags | Should Be 'None'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderOnly
+                    $Result.InheritanceFlags | Should Be 'None'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+                It 'Inheritance is ThisFolderSubfoldersAndFiles' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderSubfoldersAndFiles
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is ThisFolderAndSubfolders' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderAndSubfolders
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is ThisFolderAndFiles' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance ThisFolderAndFiles
+                    $Result.InheritanceFlags | Should Be 'ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is SubfoldersAndFilesOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance SubfoldersAndFilesOnly
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit, ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is SubfoldersOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance SubfoldersOnly
+                    $Result.InheritanceFlags | Should Be 'ContainerInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+                It 'Inheritance is FilesOnly' {
+                    $Result = New-FileSystemAuditRule @ContextParams -Inheritance FilesOnly
+                    $Result.InheritanceFlags | Should Be 'ObjectInherit'
+                    $Result.PropagationFlags | Should Be 'NoPropagateInherit'
+                }
+
+            }
+
+            Context 'ItemType is File' {
+
+                It 'Should ignore Inheritance and NoPropagateInherit' {
+                    $Result = New-FileSystemAuditRule @DescribeParams -ItemType File `
+                        -Inheritance ThisFolderSubfoldersAndFiles -NoPropagateInherit $true
+                    $Result.InheritanceFlags | Should Be 'None'
+                    $Result.PropagationFlags | Should Be 'None'
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Set-FileSystemAccessControl" {
+
+            $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+            $File = New-Item -Path $Path -ItemType File
+            $Acl = $File.GetAccessControl()
+
+            $AuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                -ArgumentList @(
+                    'BUILTIN\Users',
+                    'FullControl',
+                    'None',
+                    'None',
+                    'Failure'
+                )
+
+            $Acl.AddAuditRule($AuditRule)
+
+            It 'Should not throw' {
+                {Set-FileSystemAccessControl -Path $Path -Acl $Acl} | Should Not Throw
+            }
+
+            It 'Should throw if Path is invalid' {
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                {Set-FileSystemAccessControl -Path $Path -Acl $Acl} | Should Throw
+            }
+
+            It 'Should throw if Acl is invalid' {
+                {Set-FileSystemAccessControl -Path $Path -Acl $null} | Should Throw
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Resolve-IdentityReference" {
+
+            It 'Should resolve by SID' {
+                $Result = Resolve-IdentityReference -Identity 'S-1-5-32-545'
+                $Result.Name | Should Be 'BUILTIN\Users'
+                $Result.SID | Should Be 'S-1-5-32-545'
+            }
+
+            It 'Should resolve by Name' {
+                $Result = Resolve-IdentityReference -Identity 'Users'
+                $Result.Name | Should Be 'BUILTIN\Users'
+                $Result.SID | Should Be 'S-1-5-32-545'
+            }
+
+            It 'Should throw if Identity is invalid' {
+                {Resolve-IdentityReference -Identity $null} | Should Throw
+            }
+
+            It 'Should write a non-terminating error if Identity cannot be resolved' {
+                Resolve-IdentityReference -Identity 'GFawkes' -ErrorAction SilentlyContinue -ErrorVariable ResultError
+                $ResultError.Count | Should Be 2
+                $ResultError[1].CategoryInfo.Activity | Should Be 'Write-Error'
+            }
+
+        }
+
+    }
+
+    #endregion
+}
+finally
+{
+    #region Footer
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}

--- a/Tests/Unit/cNtfsAuditInheritance.Tests.ps1
+++ b/Tests/Unit/cNtfsAuditInheritance.Tests.ps1
@@ -1,0 +1,264 @@
+#requires -Version 4.0 -Modules Pester
+
+$Global:DSCModuleName   = 'cNtfsAccessControl'
+$Global:DSCResourceName = 'cNtfsAuditInheritance'
+
+#region Header
+
+$ModuleRoot = Split-Path -Path $Script:MyInvocation.MyCommand.Path -Parent | Split-Path -Parent | Split-Path -Parent
+
+if (
+    (-not (Test-Path -Path (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests') -PathType Container)) -or
+    (-not (Test-Path -Path (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -PathType Leaf))
+)
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests'))
+}
+
+Import-Module -Name (Join-Path -Path $ModuleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit
+
+#endregion
+
+try
+{
+    #region Unit Tests
+
+    InModuleScope $Global:DSCResourceName {
+
+        #region Helper Functions
+
+        function Set-NewTempFileAclInheritance
+        {
+            <#
+            .SYNOPSIS
+                Creates temporary files for unit testing of the cNtfsPermissionsInheritance DSC resource.
+
+            .DESCRIPTION
+                The Set-NewTempFileAclInheritance function creates temporary files and performs the following actions on them:
+                - Grants Full Control permission to the calling user to ensure the file can be removed later.
+                - Optionally disables NTFS permissions inheritance and removes inherited permissions.
+            #>
+            [CmdletBinding()]
+            param
+            (
+                [Parameter(Mandatory = $false)]
+                [ValidateNotNullOrEmpty()]
+                [String]
+                $Path = (Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())),
+
+                [Parameter(Mandatory = $false)]
+                [Boolean]
+                $Enabled = $true,
+
+                [Parameter(Mandatory = $false)]
+                [Switch]
+                $PassThru
+            )
+
+            try
+            {
+                $File = New-Item -Path $Path -ItemType File -Force -ErrorAction Stop -Verbose:$VerbosePreference
+                $Acl = $File.GetAccessControl()
+
+                if ($Enabled -eq $true -and $Acl.AreAuditRulesProtected -eq $true)
+                {
+                    $Acl.SetAuditRuleProtection($false, $false)
+                }
+                elseif ($Enabled -eq $false -and $Acl.AreAuditRulesProtected -eq $false)
+                {
+                    $Acl.SetAuditRuleProtection($true, $false)
+                }
+
+                $CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+                $AuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                    -ArgumentList @(
+                        $CurrentUser,
+                        'FullControl',
+                        'None',
+                        'None',
+                        'Failure'
+                    )
+
+                $Acl.AddAuditRule($AuditRule)
+
+                [System.IO.File]::SetAccessControl($File.FullName, $Acl)
+
+                if ($PassThru)
+                {
+                    return $File
+                }
+            }
+            catch
+            {
+                throw
+            }
+        }
+
+        #endregion
+
+        Describe "$Global:DSCResourceName\Get-TargetResource" {
+
+            Context 'Inheritance is enabled' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                Set-NewTempFileAclInheritance -Path $Path -Enabled $true
+
+                It 'Should return Enabled set to True' {
+                    $Result = Get-TargetResource -Path $Path
+                    $Result.Enabled | Should Be $true
+                }
+
+            }
+
+            Context 'Inheritance is disabled' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                Set-NewTempFileAclInheritance -Path $Path -Enabled $false
+
+                It 'Should return Enabled set to False' {
+                    $Result = Get-TargetResource -Path $Path
+                    $Result.Enabled | Should Be $false
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Test-TargetResource" {
+
+            Context 'Inheritance is enabled' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                Set-NewTempFileAclInheritance -Path $Path -Enabled $true
+
+                It 'Should return True if Enabled is True' {
+                    Test-TargetResource -Path $Path -Enabled $true | Should Be $true
+                }
+
+                It 'Should return False if Enabled is False' {
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $false
+                }
+
+            }
+
+            Context 'Inheritance is disabled' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                Set-NewTempFileAclInheritance -Path $Path -Enabled $false
+
+                It 'Should return True if Enabled is False' {
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $true
+                }
+
+                It 'Should return False if Enabled is True' {
+                    Test-TargetResource -Path $Path -Enabled $true | Should Be $false
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Set-TargetResource" {
+
+            Context 'Enabled is True' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                Set-NewTempFileAclInheritance -Path $Path -Enabled $false
+
+                It 'Should enable inheritance' {
+                    Test-TargetResource -Path $Path -Enabled $true | Should Be $false
+                    Set-TargetResource -Path $Path -Enabled $true
+                    Test-TargetResource -Path $Path -Enabled $true | Should Be $true
+                }
+
+            }
+
+            Context 'Enabled is False and PreserveInherited is True' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                $File = Set-NewTempFileAclInheritance -Path $Path -Enabled $true -PassThru
+
+                It 'Should disable inheritance and convert inherited permissions into explicit permissions' {
+
+                    $DaclBeforeSet = (Get-Acl -Path $File.FullName -Audit).Audit
+                    
+
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $false
+                    Set-TargetResource -Path $Path -Enabled $false -PreserveInherited $true
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $true
+
+                    $DaclAfterSet = (Get-Acl -Path $File.FullName -Audit).Audit
+
+                    ($DaclBeforeSet.Count - $DaclAfterSet.Count) -le 1 | Should Be $true
+
+                }
+
+            }
+
+            Context 'Enabled is False and PreserveInherited is False' {
+
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                $File = Set-NewTempFileAclInheritance -Path $Path -Enabled $true -PassThru
+
+                It 'Should disable inheritance and remove inherited permissions' {
+
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $false
+                    Set-TargetResource -Path $Path -Enabled $false -PreserveInherited $false
+                    Test-TargetResource -Path $Path -Enabled $false | Should Be $true
+
+                }
+
+            }
+
+        }
+
+        Describe "$Global:DSCResourceName\Set-FileSystemAccessControl" {
+
+            $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+            $File = New-Item -Path $Path -ItemType File
+            $Acl = $File.GetAccessControl()
+
+            $AuditRule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule `
+                -ArgumentList @(
+                    'BUILTIN\Users',
+                    'FullControl',
+                    'None',
+                    'None',
+                    'Failure'
+                )
+
+            $Acl.AddAuditRule($AuditRule)
+
+            It 'Should not throw' {
+                {Set-FileSystemAccessControl -Path $Path -Acl $Acl} | Should Not Throw
+            }
+
+            It 'Should throw if Path is invalid' {
+                $Path = 'TestDrive:\' + [System.IO.Path]::GetRandomFileName()
+                {Set-FileSystemAccessControl -Path $Path -Acl $Acl} | Should Throw
+            }
+
+            It 'Should throw if Acl is invalid' {
+                {Set-FileSystemAccessControl -Path $Path -Acl $null} | Should Throw
+            }
+
+        }
+
+    }
+
+    #endregion
+}
+finally
+{
+    #region Footer
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+}


### PR DESCRIPTION
I recently raised https://github.com/SNikalaichyk/cNtfsAccessControl/issues/11 and it turns out this was surprisingly easy. The new resource is basically a copy of cNtfsPermissionEntry but with all the relevant references updated for Audit rules. 

There are some things that can be done better here such as moving Resolve-IdentityReference and Set-FileSystemAccessControl into a shared location for both resources to avoid code duplication but i thought it best to start this PR with this so far and get some feedback before altering the code already in place. 

Let me know what you think. I have done some testing and all seems to work well. 