### PR TITLE
Fix error when NoPropagateInherit set to true in cNtfsAuditRuleInformation

### DIFF
--- a/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
+++ b/DSCResources/cNtfsAuditEntry/cNtfsAuditEntry.psm1
@@ -156,7 +156,7 @@ function Test-TargetResource
             $AuditFlags = $Instance.CimInstanceProperties.Where({$_.Name -eq 'AuditFlags'}).ForEach({$_.Value})
             $FileSystemRights = $Instance.CimInstanceProperties.Where({$_.Name -eq 'FileSystemRights'}).ForEach({$_.Value})
             $Inheritance = $Instance.CimInstanceProperties.Where({$_.Name -eq 'Inheritance'}).ForEach({$_.Value})
-            $NoPropagateInherit = $Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
+            $NoPropagateInherit = [boolean]$Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
 
             if (-not $AuditFlags)
             {
@@ -387,7 +387,7 @@ function Set-TargetResource
             $AuditFlags = $Instance.CimInstanceProperties.Where({$_.Name -eq 'AuditFlags'}).ForEach({$_.Value})
             $FileSystemRights = $Instance.CimInstanceProperties.Where({$_.Name -eq 'FileSystemRights'}).ForEach({$_.Value})
             $Inheritance = $Instance.CimInstanceProperties.Where({$_.Name -eq 'Inheritance'}).ForEach({$_.Value})
-            $NoPropagateInherit = $Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
+            $NoPropagateInherit = [boolean]$Instance.CimInstanceProperties.Where({$_.Name -eq 'NoPropagateInherit'}).ForEach({$_.Value})
 
             if (-not $AuditFlags)
             {


### PR DESCRIPTION
When setting NoPropagateInherit = $true in cNtfsAuditRuleInformation I hit the error described here: https://github.com/SNikalaichyk/cNtfsAccessControl/issues/5

I've simply applied the same fix to this class.