### PR TITLE
cNtfsPermissionEntry: Fixed error

### DIFF
--- a/DSCResources/cNtfsPermissionEntry/cNtfsPermissionEntry.psm1
+++ b/DSCResources/cNtfsPermissionEntry/cNtfsPermissionEntry.psm1
@@ -738,7 +738,14 @@ function New-FileSystemAccessRule
 
             if ($NoPropagateInherit -eq $true -and $InheritanceFlags -ne 'None')
             {
-                [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'NoPropagateInherit'
+                if ($PropagationFlags -eq 'None')
+                {
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'NoPropagateInherit'
+                }
+                else
+                {
+                    [System.Security.AccessControl.PropagationFlags]$PropagationFlags = 'NoPropagateInherit', 'InheritOnly'
+                }
             }
         }
         else

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The **cNtfsPermissionsInheritance** DSC resource provides a mechanism to manage 
 
 ## Versions
 
+### Unreleased
+
+* **cNtfsPermissionEntry**: Fixed an error when **NoPropagateInherit** is set to `$true` ([#20](https://github.com/SNikalaichyk/cNtfsAccessControl/pull/20)).
+
 ### 1.4.1 (February 6, 2019)
 
 * **cNtfsAuditRuleInformation**: Fixed an error when **NoPropagateInherit** is set to `$true` ([#14](https://github.com/SNikalaichyk/cNtfsAccessControl/pull/14)).


### PR DESCRIPTION
Fixed an error when **NoPropagateInherit** is set to `$true`
([#20](https://github.com/SNikalaichyk/cNtfsAccessControl/pull/20))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/cntfsaccesscontrol/21)
<!-- Reviewable:end -->
